### PR TITLE
Improve script robustness and fix /dev/input permissions

### DIFF
--- a/scripts/download_whisper_model.sh
+++ b/scripts/download_whisper_model.sh
@@ -5,5 +5,5 @@ set -Eeuo pipefail
 mkdir -p ~/.whisper && chmod 0700 ~/.whisper
 docker run --rm --tty --name stt-mcp-server-linux-download \
        --volume ~/.whisper:/.whisper \
-       --volume ./scripts:/app/scripts \
+       --volume `pwd`/scripts:/app/scripts \
        stt-mcp-server-linux bash -ci "python scripts/download_whisper_model.py"

--- a/scripts/restart_mcp_server.sh
+++ b/scripts/restart_mcp_server.sh
@@ -6,19 +6,67 @@ CONTAINER_NAME=${CONTAINER_NAME:-stt-mcp-server-linux}
 TMUX_SESSION=${TMUX_SESSION:-claude}
 TMUX_TMPDIR=${TMUX_TMPDIR:-"$HOME"/.tmux}
 
-docker stop "$CONTAINER_NAME" || true
-docker rm "$CONTAINER_NAME" || true
-
-DOCKER_CMD="docker run --rm --interactive --name $CONTAINER_NAME"
-DOCKER_CMD="$DOCKER_CMD --device /dev/input"
-if [ -d "/dev/snd" ]; then
-    DOCKER_CMD="$DOCKER_CMD --device /dev/snd"
+# Check if Docker is running
+if ! docker info >/dev/null 2>&1; then
+    echo "Error: Docker is not running or not accessible" >&2
+    exit 1
 fi
-DOCKER_CMD="$DOCKER_CMD --volume ~/.whisper:/.whisper"
-DOCKER_CMD="$DOCKER_CMD --volume $TMUX_TMPDIR:/.tmux"
-DOCKER_CMD="$DOCKER_CMD --volume ./tests:/app/tests"
-DOCKER_CMD="$DOCKER_CMD stt-mcp-server-linux"
-DOCKER_CMD="$DOCKER_CMD /home/nonroot/venv/bin/python /app/stt_mcp_server_linux.py"
-DOCKER_CMD="$DOCKER_CMD --session $TMUX_SESSION"
 
-eval $DOCKER_CMD
+# Stop and remove container if it exists
+if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
+    echo "Stopping and removing existing container: $CONTAINER_NAME"
+    docker stop "$CONTAINER_NAME" || true
+    docker rm "$CONTAINER_NAME" || true
+else
+    echo "Container $CONTAINER_NAME does not exist, proceeding with creation"
+fi
+
+# Create required directories
+mkdir -p "$HOME/.whisper"
+mkdir -p "$TMUX_TMPDIR"
+
+# Get input group ID for device access
+INPUT_GID=$(getent group input | cut -d: -f3)
+
+# Build Docker command using array for better handling of arguments
+DOCKER_ARGS=(
+    "run"
+    "--rm"
+    "--interactive"
+    "--name" "$CONTAINER_NAME"
+    "--device" "/dev/input"
+    "--group-add" "$INPUT_GID"
+)
+
+# Add sound device if available
+if [ -d "/dev/snd" ]; then
+    DOCKER_ARGS+=("--device" "/dev/snd")
+fi
+
+# Add volume mounts
+DOCKER_ARGS+=(
+    "--volume" "$HOME/.whisper:/.whisper"
+    "--volume" "$TMUX_TMPDIR:/.tmux"
+    "--volume" "`pwd`/tests:/app/tests"
+)
+
+# Check if Docker image exists
+if ! docker image inspect stt-mcp-server-linux >/dev/null 2>&1; then
+    echo "Error: Docker image 'stt-mcp-server-linux' not found" >&2
+    echo "Please build the image first" >&2
+    exit 1
+fi
+
+# Add image and command
+DOCKER_ARGS+=(
+    "stt-mcp-server-linux"
+    "/home/nonroot/venv/bin/python"
+    "/app/stt_mcp_server_linux.py"
+    "--session" "$TMUX_SESSION"
+)
+
+echo "Starting container with command:"
+echo "docker ${DOCKER_ARGS[*]}"
+
+# Execute Docker command
+docker "${DOCKER_ARGS[@]}"


### PR DESCRIPTION
## Summary
- Fixed `/dev/input` device access by adding the input group to the container
- Added comprehensive validation and error handling for Docker operations
- Improved script robustness with better container management
- Enhanced user feedback and debugging information

## Changes Made
- **Docker validation**: Check if Docker is running before operations
- **Smart container handling**: Verify container existence before stop/remove operations
- **Image validation**: Ensure Docker image exists before attempting to run
- **Device permissions fix**: Add `--group-add` for input group to fix keyboard device access
- **Directory creation**: Automatically create required directories
- **Better command construction**: Use arrays instead of string concatenation
- **Path fixes**: Replace relative paths with absolute paths using `pwd`

## Problem Solved
Fixes the error: `"No keyboard input devices found. Ensure you have appropriate permissions to access /dev/input devices."`

## Test Plan
- [x] Script syntax validation passes
- [x] Handles missing containers gracefully
- [x] Creates required directories automatically
- [x] Provides informative error messages
- [ ] Test actual container execution with device access

This should resolve the `/dev/input` permissions issue when running the STT MCP server in Docker containers.